### PR TITLE
Added support for the 'bits' topic

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,6 @@ class TwitchPubSub extends EventEmitter {
         super();
         if (options.defaultTopics.length < 1)throw new Error('missing default topic');
         this._token = options.authToken;
-	console.log(this._token);
         this._autoreconnect = options.reconnect || true;
 
         this._pending = {};
@@ -19,7 +18,6 @@ class TwitchPubSub extends EventEmitter {
         this._pingInterval = null;
         this._pingTimeout = null;
         this._topics = options.defaultTopics;
-	console.log(this._topics);
         this._connect();
     }
 
@@ -32,7 +30,7 @@ class TwitchPubSub extends EventEmitter {
             this._ws.send(JSON.stringify({
                 type: 'LISTEN',
                 nonce: this._initial,
-                data: {topics: this._topics, auth_token: (this._token)}
+                data: {topics: this._topics, auth_token: (this._token ? this._token : undefined)}
             }));
             this.emit('connect');
         });
@@ -54,7 +52,6 @@ class TwitchPubSub extends EventEmitter {
         this._ws.on('message', (msg) => {
             try {
                 msg = JSON.parse(msg);
-		console.log(msg);
                 this.emit('raw', msg);
                 if (msg.type === 'RESPONSE') {
                     if (msg.nonce === this._initial) {


### PR DESCRIPTION
Bits, unlike video-playback, needs the channel-id which can be retrieved by making an unauthenticated, or authenticated request to GET /channels/:channel/ - documentation found [here](https://github.com/justintv/Twitch-API/blob/master/v3_resources/channels.md#get-channelschannel). You will also need to get an access token to the channel you want to listen to using the twitch oAuth system - documentation found [here](https://github.com/justintv/Twitch-API/blob/master/authentication.md). Any scope will work.

Problems: 
The function topic() will not return the correct built topic, so as you can see in the example I have to directly put in the correct topic form in instantiation.

Example code: 
```javascript
var Realtime = require('twitch-realtime');
 
var realtime = new Realtime({defaultTopics:["channel-bitsevents.##channelid##", "video-playback.bajheera"], authToken:'XXXX'});

realtime.on('viewcount',(data)=>{
    /*do stuff
          { time: 13246, //current time on the server
            channel: 'channel', //channel which viewcount changed
            viewers: 123 //new viewercount
          }
    */
});

realtime.on('bits',(data)=>{
    /*do stuff
          { user_name: 'username', //username of bits cheerer
            channel_name: 'channel', //channel which user cheered
            time: 123456, //server time of donation
            chat_message: 'Message', //message sent with bits cheer
            bits_used: 123, //amount cheered by user
            total_bits_used: 9999, //total amount cheered ever by user to this specific channel
            context: 'cheer'//context of cheer
          }
    */
});
```